### PR TITLE
fix: Strengthen the param check of range query

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5367,6 +5367,11 @@ impl<'a> Parser<'a> {
                 fill = Some(self.parse_identifier()?.to_string());
             }
         }
+        if align.is_none() && fill.is_some() {
+            return Err(ParserError::ParserError(
+                "ALIGN argument cannot be omitted in the range select query".into(),
+            ));
+        }
         let projection = if let Some((align, by)) = align {
             let fill = fill.unwrap_or(String::new());
             let by_num = FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
@@ -5400,6 +5405,11 @@ impl<'a> Parser<'a> {
                                         FunctionArgExpr::Expr(Expr::Value(align.clone())),
                                     ));
                                     return Ok(Some(Expr::Function(range_func)));
+                                } else {
+                                    return Err(ParserError::ParserError(format!(
+                                        "RANGE argument not found in {}",
+                                        e
+                                    )));
                                 }
                             }
                             Ok(None)


### PR DESCRIPTION
Strengthen parameter verification, not allowed to omit `range` or `align` in range query.

Case like will failed

`SELECT sum(metrics) FROM t ALIGN '1h' FILL NULL;`
`SELECT sum(metrics) RANGE '10m' FILL MAX FROM t FILL NULL;`

but allow case like

`SELECT covariance(cos(a), sin(b)) RANGE '5m' FILL NULL FROM t ALIGN '1h' FILL NULL;`