### PR TITLE
feat: range expr can decorate any expr

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -588,6 +588,7 @@ impl<'a> Parser<'a> {
         let mut expr = self.parse_prefix()?;
         debug!("prefix: {:?}", expr);
         loop {
+            expr = self.parse_range_expr(expr)?;
             let next_precedence = self.get_next_precedence()?;
             debug!("next precedence: {:?}", next_precedence);
 
@@ -596,6 +597,78 @@ impl<'a> Parser<'a> {
             }
 
             expr = self.parse_infix(expr, next_precedence)?;
+        }
+        Ok(expr)
+    }
+
+    fn parse_range_expr(&mut self, expr: Expr) -> Result<Expr, ParserError> {
+        let index = self.index;
+        let range = if self.parse_keyword(Keyword::RANGE) {
+            // Make sure Range followed by a value, or it will be confused with window function syntax
+            // e.g. `COUNT(*) OVER (ORDER BY a RANGE BETWEEN INTERVAL '1 DAY' PRECEDING AND INTERVAL '1 DAY' FOLLOWING)`
+            if let Ok(value) = self.parse_value() {
+                value.verify_duration()?;
+                value
+            } else {
+                self.index = index;
+                return Ok(expr);
+            }
+        } else if self.parse_keyword(Keyword::FILL) {
+            return Err(ParserError::ParserError(
+                "Detect FILL keyword in SELECT Expr, but no RANGE given or RANGE after FILL".into(),
+            ));
+        } else {
+            return Ok(expr);
+        };
+        let fill = if self.parse_keyword(Keyword::FILL) {
+            Value::SingleQuotedString(self.next_token().to_string())
+        } else {
+            Value::SingleQuotedString(String::new())
+        };
+        // Recursively rewrite function nested in expr to range function when RANGE keyword appear in Expr
+        // Treat Function Argument as scalar function, not execute rewrite
+        // follow the pattern of `range_fn(func_name, argc, [argv], range, fill)`, `argc` is the number of func_name arguments
+        // if `fill` is `None`, the last parameter will be a empty single quoted string for placeholder
+        // rate(metrics) RANGE '5m'            ->    range_fn('rate', '1', metrics, '5m', '')
+        // rate()        RANGE '5m' FILL MAX   ->    range_fn('rate', '0', '5m', 'MAX')
+        let mut rewrite_count = 0;
+        let expr = rewrite_calculation_expr(&expr, false, &mut |e: &Expr| {
+            match e {
+                Expr::Function(func) => {
+                    // args_num = function_name + original_args + range + fill
+                    let mut args = Vec::with_capacity(3 + func.args.len());
+                    args.push(FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                        Value::SingleQuotedString(func.name.to_string()),
+                    ))));
+                    args.push(FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                        Value::SingleQuotedString(func.args.len().to_string()),
+                    ))));
+                    args.extend(func.args.clone());
+                    args.push(FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                        range.clone(),
+                    ))));
+                    args.push(FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                        fill.clone(),
+                    ))));
+                    let range_func = Function {
+                        name: ObjectName(vec![Ident::new("range_fn")]),
+                        args,
+                        over: None,
+                        distinct: false,
+                        special: false,
+                        order_by: vec![],
+                    };
+                    rewrite_count += 1;
+                    Ok(Some(Expr::Function(range_func)))
+                }
+                _ => Ok(None),
+            }
+        })?;
+        if rewrite_count == 0 {
+            return Err(ParserError::ParserError(format!(
+                "Can't use the RANGE keyword in Expr {} without function",
+                expr
+            )));
         }
         Ok(expr)
     }
@@ -5364,7 +5437,7 @@ impl<'a> Parser<'a> {
                         "Duplicate FILL keyword detected in SELECT clause.".into(),
                     ));
                 }
-                fill = Some(self.parse_identifier()?.to_string());
+                fill = Some(self.next_token().to_string());
             }
         }
         if align.is_none() && fill.is_some() {
@@ -5383,9 +5456,10 @@ impl<'a> Parser<'a> {
                 .collect::<Vec<_>>();
             // range_fn(func_name, argc, [argv], range, fill, byc, [byv], align)
             // argc/byc are length of variadic arguments argv/byv
-            let align_fill_rewrite =
+            let mut rewrite_count = 0;
+            let mut align_fill_rewrite =
                 |expr: Expr| {
-                    rewrite_calculation_expr(&expr, &|e: &Expr| match e {
+                    rewrite_calculation_expr(&expr, true, &mut |e: &Expr| match e {
                         Expr::Function(func) => {
                             if let Some(name) = func.name.0.first() {
                                 if name.value.as_str() == "range_fn" {
@@ -5404,12 +5478,8 @@ impl<'a> Parser<'a> {
                                     range_func.args.push(FunctionArg::Unnamed(
                                         FunctionArgExpr::Expr(Expr::Value(align.clone())),
                                     ));
+                                    rewrite_count += 1;
                                     return Ok(Some(Expr::Function(range_func)));
-                                } else {
-                                    return Err(ParserError::ParserError(format!(
-                                        "RANGE argument not found in {}",
-                                        e
-                                    )));
                                 }
                             }
                             Ok(None)
@@ -5417,7 +5487,7 @@ impl<'a> Parser<'a> {
                         _ => Ok(None),
                     })
                 };
-            projection
+            let rewrite_projection = projection
                 .into_iter()
                 .map(|select_item| match select_item {
                     SelectItem::UnnamedExpr(expr) => {
@@ -5431,7 +5501,13 @@ impl<'a> Parser<'a> {
                         "Wildcard `*` is not allowed in range select query".into(),
                     )),
                 })
-                .collect::<Result<Vec<_>, ParserError>>()?
+                .collect::<Result<Vec<_>, ParserError>>()?;
+            if rewrite_count == 0 {
+                return Err(ParserError::ParserError(
+                    "Illegal Range select, no RANGE keyword found in any SelectItem".into(),
+                ));
+            }
+            rewrite_projection
         } else {
             projection
         };
@@ -6506,68 +6582,6 @@ impl<'a> Parser<'a> {
                 } else {
                     expr
                 };
-                let range = if self.parse_keyword(Keyword::RANGE) {
-                    let value = self.parse_value()?;
-                    value.verify_duration()?;
-                    Some(value)
-                } else {
-                    None
-                };
-                let fill = if self.parse_keyword(Keyword::FILL) {
-                    if range.is_none() {
-                        return Err(ParserError::ParserError(
-                            "Detect FILL keyword in SELECT item, but no RANGE given or RANGE after FILL".to_string()
-                        ));
-                    }
-                    Some(Value::SingleQuotedString(
-                        self.parse_identifier()?.to_string(),
-                    ))
-                } else {
-                    None
-                };
-                // Recursively rewrite function nested in expr to range function when RANGE keyword appear in Select item
-                // follow the pattern of `range_fn(func_name, argc, [argv], range, fill)`, `argc` is the number of func_name arguments
-                // if `fill` is `None`, the last parameter will be a empty single quoted string for placeholder
-                // rate(metrics) RANGE '5m'            ->    range_fn('rate', '1', metrics, '5m', '')
-                // rate()        RANGE '5m' FILL MAX   ->    range_fn('rate', '0', '5m', 'MAX')
-                let expr = if let Some(range) = range {
-                    let fill = fill.unwrap_or(Value::SingleQuotedString(String::new()));
-                    rewrite_calculation_expr(&expr, &|e: &Expr| {
-                        match e {
-                            Expr::Function(func) => {
-                                // args_num = function_name + original_args + range + fill
-                                let mut args = Vec::with_capacity(3 + func.args.len());
-                                args.push(FunctionArg::Unnamed(FunctionArgExpr::Expr(
-                                    Expr::Value(Value::SingleQuotedString(func.name.to_string())),
-                                )));
-                                args.push(FunctionArg::Unnamed(FunctionArgExpr::Expr(
-                                    Expr::Value(Value::SingleQuotedString(
-                                        func.args.len().to_string(),
-                                    )),
-                                )));
-                                args.extend(func.args.clone());
-                                args.push(FunctionArg::Unnamed(FunctionArgExpr::Expr(
-                                    Expr::Value(range.clone()),
-                                )));
-                                args.push(FunctionArg::Unnamed(FunctionArgExpr::Expr(
-                                    Expr::Value(fill.clone()),
-                                )));
-                                let range_func = Function {
-                                    name: ObjectName(vec![Ident::new("range_fn")]),
-                                    args,
-                                    over: None,
-                                    distinct: false,
-                                    special: false,
-                                    order_by: vec![],
-                                };
-                                Ok(Some(Expr::Function(range_func)))
-                            }
-                            _ => Ok(None),
-                        }
-                    })?
-                } else {
-                    expr
-                };
 
                 self.parse_optional_alias(keywords::RESERVED_FOR_COLUMN_ALIAS)
                     .map(|alias| match alias {
@@ -7275,22 +7289,91 @@ impl Word {
 /// * `Ok(Some(replacement_expr))`: A replacement `Expr` is provided, use replacement `Expr`.
 /// * `Ok(None)`: A replacement `Expr` is not provided, use old `Expr`.
 /// * `Err(err)`: Any error returned.
-fn rewrite_calculation_expr<F>(expr: &Expr, replacement_fn: &F) -> Result<Expr, ParserError>
+fn rewrite_calculation_expr<F>(
+    expr: &Expr,
+    rewrite_func_expr: bool,
+    replacement_fn: &mut F,
+) -> Result<Expr, ParserError>
 where
-    F: Fn(&Expr) -> Result<Option<Expr>, ParserError>,
+    F: FnMut(&Expr) -> Result<Option<Expr>, ParserError>,
 {
     match replacement_fn(expr)? {
         Some(replacement) => Ok(replacement),
         None => match expr {
             Expr::BinaryOp { left, op, right } => Ok(Expr::BinaryOp {
-                left: Box::new(rewrite_calculation_expr(left, replacement_fn)?),
+                left: Box::new(rewrite_calculation_expr(
+                    left,
+                    rewrite_func_expr,
+                    replacement_fn,
+                )?),
                 op: op.clone(),
-                right: Box::new(rewrite_calculation_expr(right, replacement_fn)?),
+                right: Box::new(rewrite_calculation_expr(
+                    right,
+                    rewrite_func_expr,
+                    replacement_fn,
+                )?),
             }),
             Expr::Nested(expr) => Ok(Expr::Nested(Box::new(rewrite_calculation_expr(
                 expr,
+                rewrite_func_expr,
                 replacement_fn,
             )?))),
+            Expr::Cast { expr, data_type } => Ok(Expr::Cast {
+                expr: Box::new(rewrite_calculation_expr(
+                    expr,
+                    rewrite_func_expr,
+                    replacement_fn,
+                )?),
+                data_type: data_type.clone(),
+            }),
+            Expr::TryCast { expr, data_type } => Ok(Expr::TryCast {
+                expr: Box::new(rewrite_calculation_expr(
+                    expr,
+                    rewrite_func_expr,
+                    replacement_fn,
+                )?),
+                data_type: data_type.clone(),
+            }),
+            Expr::SafeCast { expr, data_type } => Ok(Expr::SafeCast {
+                expr: Box::new(rewrite_calculation_expr(
+                    expr,
+                    rewrite_func_expr,
+                    replacement_fn,
+                )?),
+                data_type: data_type.clone(),
+            }),
+            // Scalar function `ceil(val)` will be parse as `Expr::Ceil` instead of `Expr::Function`
+            Expr::Ceil { expr, field } => Ok(Expr::Ceil {
+                expr: Box::new(rewrite_calculation_expr(
+                    expr,
+                    rewrite_func_expr,
+                    replacement_fn,
+                )?),
+                field: *field,
+            }),
+            // Scalar function `floor(val)` will be parse as `Expr::Floor` instead of `Expr::Function`
+            Expr::Floor { expr, field } => Ok(Expr::Floor {
+                expr: Box::new(rewrite_calculation_expr(
+                    expr,
+                    rewrite_func_expr,
+                    replacement_fn,
+                )?),
+                field: *field,
+            }),
+            Expr::Function(func) if rewrite_func_expr => {
+                let mut func = func.clone();
+                for fn_arg in &mut func.args {
+                    if let FunctionArg::Named {
+                        arg: FunctionArgExpr::Expr(expr),
+                        ..
+                    }
+                    | FunctionArg::Unnamed(FunctionArgExpr::Expr(expr)) = fn_arg
+                    {
+                        *expr = rewrite_calculation_expr(expr, rewrite_func_expr, replacement_fn)?;
+                    }
+                }
+                Ok(Expr::Function(func))
+            }
             expr => Ok(expr.clone()),
         },
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -7137,52 +7137,52 @@ fn parse_range_select() {
     // rewrite format `range_fn(func_name, argc, [argv], range, fill, byc, [byv], align)`
     // regular without by
     assert_sql("SELECT rate(metrics) RANGE '5m', sum(metrics) RANGE '10m' FILL MAX, sum(metrics) RANGE '10m' FROM t ALIGN '1h' FILL NULL;",
-     "SELECT range_fn('rate', '1', metrics, '5m', 'NULL', '0', '1h'), range_fn('sum', '1', metrics, '10m', 'MAX', '0', '1h'), range_fn('sum', '1', metrics, '10m', 'NULL', '0', '1h') FROM t");
+     "SELECT range_fn(rate(metrics), '5m', 'NULL', '0', '1h'), range_fn(sum(metrics), '10m', 'MAX', '0', '1h'), range_fn(sum(metrics), '10m', 'NULL', '0', '1h') FROM t");
 
     // regular with by
     assert_sql("SELECT rate(metrics) RANGE '5m', sum(metrics) RANGE '10m' FILL MAX, sum(metrics) RANGE '10m' FROM t ALIGN '1h' by ((a+1)/2, b) FILL NULL;",
-    "SELECT range_fn('rate', '1', metrics, '5m', 'NULL', '2', (a + 1) / 2, b, '1h'), range_fn('sum', '1', metrics, '10m', 'MAX', '2', (a + 1) / 2, b, '1h'), range_fn('sum', '1', metrics, '10m', 'NULL', '2', (a + 1) / 2, b, '1h') FROM t");
+    "SELECT range_fn(rate(metrics), '5m', 'NULL', '2', (a + 1) / 2, b, '1h'), range_fn(sum(metrics), '10m', 'MAX', '2', (a + 1) / 2, b, '1h'), range_fn(sum(metrics), '10m', 'NULL', '2', (a + 1) / 2, b, '1h') FROM t GROUP BY a, b");
 
     // expression1
     assert_sql(
         "SELECT avg(a/2 + 1) RANGE '5m' FILL NULL FROM t ALIGN '1h' FILL NULL;",
-        "SELECT range_fn('avg', '1', a / 2 + 1, '5m', 'NULL', '0', '1h') FROM t",
+        "SELECT range_fn(avg(a / 2 + 1), '5m', 'NULL', '0', '1h') FROM t",
     );
 
     // expression2
     assert_sql(
         "SELECT avg(a) RANGE '5m' FILL NULL + 1 FROM t ALIGN '1h' FILL NULL;",
-        "SELECT range_fn('avg', '1', a, '5m', 'NULL', '0', '1h') + 1 FROM t",
+        "SELECT range_fn(avg(a), '5m', 'NULL', '0', '1h') + 1 FROM t",
     );
 
     // expression3
     assert_sql(
         "SELECT ((avg(a) + sum(b))/2) RANGE '5m' FILL NULL FROM t ALIGN '1h' FILL NULL;",
-        "SELECT ((range_fn('avg', '1', a, '5m', 'NULL', '0', '1h') + range_fn('sum', '1', b, '5m', 'NULL', '0', '1h')) / 2) FROM t",
+        "SELECT ((range_fn(avg(a), '5m', 'NULL', '0', '1h') + range_fn(sum(b), '5m', 'NULL', '0', '1h')) / 2) FROM t",
     );
 
     // expression4
     assert_sql(
         "SELECT covariance(a, b) RANGE '5m' FILL NULL FROM t ALIGN '1h' FILL NULL;",
-        "SELECT range_fn('covariance', '2', a, b, '5m', 'NULL', '0', '1h') FROM t",
+        "SELECT range_fn(covariance(a, b), '5m', 'NULL', '0', '1h') FROM t",
     );
 
     // expression5
     assert_sql(
         "SELECT covariance(cos(a), sin(b)) RANGE '5m' FILL NULL FROM t ALIGN '1h' FILL NULL;",
-        "SELECT range_fn('covariance', '2', cos(a), sin(b), '5m', 'NULL', '0', '1h') FROM t",
+        "SELECT range_fn(covariance(cos(a), sin(b)), '5m', 'NULL', '0', '1h') FROM t",
     );
 
     // expression6
     assert_sql(
         "SELECT ((covariance(a+1, b/2) + sum(b))/2) RANGE '5m' FILL NULL FROM t ALIGN '1h' FILL NULL;",
-        "SELECT ((range_fn('covariance', '2', a + 1, b / 2, '5m', 'NULL', '0', '1h') + range_fn('sum', '1', b, '5m', 'NULL', '0', '1h')) / 2) FROM t",
+        "SELECT ((range_fn(covariance(a + 1, b / 2), '5m', 'NULL', '0', '1h') + range_fn(sum(b), '5m', 'NULL', '0', '1h')) / 2) FROM t",
     );
 
     // FILL... ALIGN...
     assert_sql(
         "SELECT sum(metrics) RANGE '10m' FROM t FILL NULL ALIGN '1h';",
-        "SELECT range_fn('sum', '1', metrics, '10m', 'NULL', '0', '1h') FROM t",
+        "SELECT range_fn(sum(metrics), '10m', 'NULL', '0', '1h') FROM t",
     );
 
     // FILL ... FILL ...
@@ -7242,42 +7242,57 @@ fn parse_range_in_expr() {
     // use range in expr
     assert_sql(
         "SELECT rate(a) RANGE '6m' + 1 FROM t ALIGN '1h' FILL NULL;",
-        "SELECT range_fn('rate', '1', a, '6m', 'NULL', '0', '1h') + 1 FROM t",
+        "SELECT range_fn(rate(a), '6m', 'NULL', '0', '1h') + 1 FROM t",
     );
 
     assert_sql(
         "SELECT sin(rate(a) RANGE '6m' + 1) FROM t ALIGN '1h' FILL NULL;",
-        "SELECT sin(range_fn('rate', '1', a, '6m', 'NULL', '0', '1h') + 1) FROM t",
+        "SELECT sin(range_fn(rate(a), '6m', 'NULL', '0', '1h') + 1) FROM t",
+    );
+
+    assert_sql(
+        "SELECT sin(first_value(a ORDER BY b ASC NULLS LAST) RANGE '6m' + 1) FROM t ALIGN '1h' by (tag0, tag1) FILL NULL;",
+        "SELECT sin(range_fn(first_value(a ORDER BY b ASC NULLS LAST), '6m', 'NULL', '2', tag0, tag1, '1h') + 1) FROM t GROUP BY tag0, tag1",
+    );
+
+    assert_sql(
+        "SELECT sin(count(distinct a) RANGE '6m' + 1) FROM t ALIGN '1h' by (tag0, tag1) FILL NULL;",
+        "SELECT sin(range_fn(count(DISTINCT a), '6m', 'NULL', '2', tag0, tag1, '1h') + 1) FROM t GROUP BY tag0, tag1",
+    );
+
+    assert_sql(
+        "SELECT sin(rank() OVER (PARTITION BY a ORDER BY b DESC) RANGE '6m' + 1) FROM t ALIGN '1h' by (tag0, tag1) FILL NULL;",
+        "SELECT sin(range_fn(rank() OVER (PARTITION BY a ORDER BY b DESC), '6m', 'NULL', '2', tag0, tag1, '1h') + 1) FROM t GROUP BY tag0, tag1",
     );
 
     assert_sql(
         "SELECT sin(cos(round(sin(avg(a + b) RANGE '5m' + 1)))) FROM test ALIGN '1h' by (tag_0,tag_1);",
-        "SELECT sin(cos(round(sin(range_fn('avg', '1', a + b, '5m', '', '2', tag_0, tag_1, '1h') + 1)))) FROM test",
+        "SELECT sin(cos(round(sin(range_fn(avg(a + b), '5m', '', '2', tag_0, tag_1, '1h') + 1)))) FROM test GROUP BY tag_0, tag_1",
     );
 
     assert_sql("SELECT rate(a) RANGE '6m' + rate(a) RANGE '5m' FROM t ALIGN '1h' FILL NULL;",
-    "SELECT range_fn('rate', '1', a, '6m', 'NULL', '0', '1h') + range_fn('rate', '1', a, '5m', 'NULL', '0', '1h') FROM t");
+    "SELECT range_fn(rate(a), '6m', 'NULL', '0', '1h') + range_fn(rate(a), '5m', 'NULL', '0', '1h') FROM t");
 
-    assert_sql("SELECT (rate(a) RANGE '6m' + rate(a) RANGE '5m')/b + a * rate(a) RANGE '5m' FROM t ALIGN '1h' FILL NULL;",
-    "SELECT (range_fn('rate', '1', a, '6m', 'NULL', '0', '1h') + range_fn('rate', '1', a, '5m', 'NULL', '0', '1h')) / b + a * range_fn('rate', '1', a, '5m', 'NULL', '0', '1h') FROM t");
+    assert_sql("SELECT (rate(a) RANGE '6m' + rate(a) RANGE '5m')/b + b * rate(a) RANGE '5m' FROM t ALIGN '1h' FILL NULL;",
+    "SELECT (range_fn(rate(a), '6m', 'NULL', '0', '1h') + range_fn(rate(a), '5m', 'NULL', '0', '1h')) / b + b * range_fn(rate(a), '5m', 'NULL', '0', '1h') FROM t GROUP BY b");
 
     assert_sql("SELECT round(max(a+1) Range '5m' FILL NULL), sin((max(a) + 1) Range '5m' FILL NULL) from t ALIGN '1h' by (b) FILL NULL;", 
-    "SELECT round(range_fn('max', '1', a + 1, '5m', 'NULL', '1', b, '1h')), sin((range_fn('max', '1', a, '5m', 'NULL', '1', b, '1h') + 1)) FROM t");
+    "SELECT round(range_fn(max(a + 1), '5m', 'NULL', '1', b, '1h')), sin((range_fn(max(a), '5m', 'NULL', '1', b, '1h') + 1)) FROM t GROUP BY b");
 
     assert_sql(
-        "SELECT floor(ceil((min(a *2) + max(a *2)) RANGE '20s' + 1.0)) FROM t ALIGN '1h';",
-        "SELECT FLOOR(CEIL((range_fn('min', '1', a * 2, '20s', '', '0', '1h') + range_fn('max', '1', a * 2, '20s', '', '0', '1h')) + 1.0)) FROM t",
+        "SELECT floor(ceil((min(a * 2) + max(a *2)) RANGE '20s' + 1.0)) FROM t ALIGN '1h';",
+        "SELECT FLOOR(CEIL((range_fn(min(a * 2), '20s', '', '0', '1h') + range_fn(max(a * 2), '20s', '', '0', '1h')) + 1.0)) FROM t",
     );
 
     assert_sql(
         "SELECT gcd(CAST(max(a + 1) Range '5m' FILL NULL AS Int64), CAST(b AS Int64)) + round(max(c+1) Range '6m' FILL NULL + 1) + max(d+3) Range '10m' FILL NULL * CAST(e AS Float64) + 1 FROM test ALIGN '1h' by (f, g);",
-        "SELECT gcd(CAST(range_fn('max', '1', a + 1, '5m', 'NULL', '2', f, g, '1h') AS Int64), CAST(b AS Int64)) + round(range_fn('max', '1', c + 1, '6m', 'NULL', '2', f, g, '1h') + 1) + range_fn('max', '1', d + 3, '10m', 'NULL', '2', f, g, '1h') * CAST(e AS Float64) + 1 FROM test",
+        "SELECT gcd(CAST(range_fn(max(a + 1), '5m', 'NULL', '2', f, g, '1h') AS Int64), CAST(b AS Int64)) + round(range_fn(max(c + 1), '6m', 'NULL', '2', f, g, '1h') + 1) + range_fn(max(d + 3), '10m', 'NULL', '2', f, g, '1h') * CAST(e AS Float64) + 1 FROM test GROUP BY b, e, f, g",
     );
 
     // Legal syntax but illegal semantic, nested range semantics are problematic, leave semantic problem to greptimedb
     assert_sql(
         "SELECT rate(max(a) RANGE '6m') RANGE '6m' + 1 FROM t ALIGN '1h' FILL NULL;",
-        "SELECT range_fn('rate', '1', range_fn('max', '1', a, '6m', ''), '6m', 'NULL', '0', '1h') + 1 FROM t",
+        "SELECT range_fn(rate(range_fn(max(a), '6m', '')), '6m', 'NULL', '0', '1h') + 1 FROM t",
     );
 
     assert_sql_err(


### PR DESCRIPTION
## Nest expr

A range expression like `RANGE '5m' FILL NULL` can be nested behind any expression, but the expression must contain at least one aggregate function.

The following SQL is now recognized by `sqlparser` and is semantically equivalent to the following subquery

```sql
Select
    round(max(a+1) Range '5m' FILL NULL),
    sin((max(a) + 1) Range '5m' FILL NULL)，
from
    test
ALIGN '1h' by (b) FILL NULL;
```

```sql
Select round(x), sin(y + 1) from
    (
        select max(a+1) Range '5m' FILL NULL as x, max(a) Range '5m' FILL NULL as y
            from
        test
            ALIGN '1h' by (b) FILL NULL;
    )
;
```

## Change rewrite format

Change the rewrite format to `range_fn(func, range, fill, byc, [byv], align)`. Let `func` be parsed by datafusion to correctly deduce the type of range expression. Because datafusion uses aggregation plan to analyze the rewritten SQL, we need to write the fields without aggregation into group by.

For example, 

`SELECT sin(cos(round(sin(avg(a + b) RANGE '5m' + 1)))) FROM test ALIGN '1h' by (tag_0,tag_1);` 

will be rewrite to

`SELECT sin(cos(round(sin(range_fn(avg(a + b), '5m', '', '2', tag_0, tag_1, '1h') + 1)))) FROM test GROUP BY tag_0, tag_1;`